### PR TITLE
Complete US3

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,5 +1,6 @@
 class BulkDiscountsController < ApplicationController
   before_action :find_merchant, only: [:index, :new, :create]
+  before_action :find_discount_and_merchant, only: [:destroy]
 
   def index
     @bulk_discounts = @merchant.bulk_discounts
@@ -20,8 +21,19 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def destroy
+    @discount.destroy
+    redirect_to merchant_bulk_discounts_path(@merchant)
+  end
+
   def find_merchant
     @merchant = Merchant.find(params[:merchant_id])
   end
+
+  def find_discount_and_merchant
+    @merchant = Merchant.find(params[:merchant_id])
+    @discount = @merchant.bulk_discounts.find(params[:id])
+  end
+
 
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,11 +1,13 @@
 <h2><%= "#{@merchant.name} Discount Index" %></h2>
-<p><%= link_to 'Create a Discount', new_merchant_bulk_discount_path(@merchant) %></p>
+<p>• <%= link_to 'Create a Discount', new_merchant_bulk_discount_path(@merchant) %> •</p>
 
 <% @bulk_discounts.each do |discount| %>
   <div id="discount-<%= discount.id %>">
     <p><b>Name: </b><%= discount.name %></p>
     <p><b>Deal: </b><%= "#{discount.percentage}% off" %></p>
     <p><b>Quantity Required: </b><%= discount.quantity_threshold %></p>
-      <p><%= link_to "Visit", merchant_bulk_discount_path(@merchant, discount) %></p>
+      <p>• <%= link_to "Visit", merchant_bulk_discount_path(@merchant, discount) %> •</p>
+      <p><%= button_to "Delete This Discount", {:controller => :bulk_discounts, :action => 'destroy', :id => discount.id }, :method => :delete %></p>
+      ______________________________
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,6 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :show, :edit, :new, :create]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :create, :new]
+    resources :bulk_discounts, only: [:index, :destroy, :show, :create, :new]
   end
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -58,5 +58,35 @@ RSpec.describe "Merchant Bulk Discount Index Page" do
         end
       end
     end
+
+    describe "When I visit my bulk discounts index" do
+      it "Then next to each bulk discount I see a button to delete it" do
+        visit "/merchants/#{@merchant.id}/bulk_discounts"
+
+        within("#discount-#{@discount1.id}") do
+          expect(page).to have_button("Delete This Discount")
+        end
+
+        within("#discount-#{@discount2.id}") do
+          expect(page).to have_button("Delete This Discount")
+        end
+
+      end
+
+      describe "When I click this button" do
+        it "Then I am redirected back to the bulk discounts index page. And I no longer see the discount listed" do
+          visit "/merchants/#{@merchant.id}/bulk_discounts"
+
+          within("#discount-#{@discount2.id}") do
+            click_button("Delete This Discount")
+          end
+
+          expect(current_path).to eq("/merchants/#{@merchant.id}/bulk_discounts")
+          expect(page).to_not have_content("Name: Test2")
+          expect(page).to_not have_content("Deal: 15% off")
+          expect(page).to_not have_content("Quantity Required: 15")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed