### PR TITLE
Complete US5

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,6 +1,6 @@
 class BulkDiscountsController < ApplicationController
   before_action :find_merchant, only: [:index, :new, :create]
-  before_action :find_discount_and_merchant, only: [:destroy, :show]
+  before_action :find_discount_and_merchant, only: [:destroy, :show, :edit, :update]
 
   def index
     @bulk_discounts = @merchant.bulk_discounts
@@ -24,8 +24,21 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @bulk_discount.update(bulk_discount_params)
+      redirect_to merchant_bulk_discount_path(@merchant, @bulk_discount)
+      flash[:message] = 'Information successfully updated'
+    else
+      redirect_to edit_merchant_bulk_discount_path(@merchant, @bulk_discount)
+      flash[:error] = 'Required content missing or number input(s) are invalid'
+    end
+  end
+
   def destroy
-    @discount.destroy
+    @bulk_discount.destroy
     redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
@@ -35,7 +48,12 @@ class BulkDiscountsController < ApplicationController
 
   def find_discount_and_merchant
     @merchant = Merchant.find(params[:merchant_id])
-    @discount = @merchant.bulk_discounts.find(params[:id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+  end
+
+  private
+  def bulk_discount_params
+    params.require(:bulk_discount).permit(:name, :percentage, :quantity_threshold)
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,6 @@ class ItemsController < ApplicationController
   end
 
   private
-
   def item_params
     params.require(:item).permit(:name, :description, :unit_price)
   end

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,13 @@
+<h2><%= "Edit #{@bulk_discount.name}" %></h2>
+
+  <div id= "update_discount">
+    <%= form_with model: @bulk_discount, url: merchant_bulk_discount_path(@merchant, @bulk_discount), local: true do |form| %>
+      <%= form.label "Name:" %>
+      <%= form.text_field :name %>
+      <%= form.label "Discount percentage:" %>
+      <%= form.number_field :percentage %>
+      <%= form.label "Quantity required:"%>
+      <%= form.number_field :quantity_threshold %>
+      <%= form.submit "Update Discount" %>
+    <% end %>
+  </div>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,3 +1,4 @@
-<h2><%= "#{@discount.name} Show Page" %></h2>
-<p><b>Deal: </b><%= "#{@discount.percentage}% off" %></p>
-<p><b>Quantity Required: </b><%= "#{@discount.quantity_threshold}" %></p>
+<h2><%= "#{@bulk_discount.name} Show Page" %></h2>
+  <p><b>Deal: </b><%= "#{@bulk_discount.percentage}% off" %></p>
+  <p><b>Quantity Required: </b><%= "#{@bulk_discount.quantity_threshold}" %></p>
+<p>• <%= link_to "Edit", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %> •</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,11 +13,12 @@ Rails.application.routes.draw do
   # merchants
   get '/merchants/:merchant_id/dashboard', to: 'merchants#show'
   patch 'merchants/:merchant_id/items/:id', to: 'items#update'
+  patch 'merchants/:merchant_id/bulk_discounts/:id', to: 'bulk_discounts#update'
 
   resources :merchants, only: [] do
     resources :items, only: [:index, :show, :edit, :new, :create]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :destroy, :show, :create, :new]
+    resources :bulk_discounts, only: [:index, :destroy, :show, :create, :new, :edit]
   end
 end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,118 @@
+# 5: Merchant Bulk Discount Edit
+
+# As a merchant
+# When I visit my bulk discount show page
+# Then I see a link to edit the bulk discount
+# When I click this link
+# Then I am taken to a new page with a form to edit the discount
+# And I see that the discounts current attributes are pre-poluated in the form
+# When I change any/all of the information and click submit
+# Then I am redirected to the bulk discount's show page
+# And I see that the discount's attributes have been updated
+require 'rails_helper'
+
+RSpec.describe "Merchant Bulk Discounts Edit page" do
+
+  before :each do
+    @merchant = Merchant.create!(name: 'Marvel')
+    @discount1 = BulkDiscount.create!(name: "Test1", percentage: 10, quantity_threshold: 10, merchant: @merchant)
+  end
+
+  describe "As a merchant" do
+    describe "When I visit my bulk discount show page" do
+      it "Then I see a link to edit the bulk discount" do
+        visit "/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}"
+
+        expect(page).to have_link("Edit")
+      end
+
+      describe "When I click this link" do
+        it "Then I am taken to a new page with a form to edit the discount. And I see that the discounts current attributes are pre-populated in the form" do
+          visit "/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}"
+
+          click_link("Edit")
+
+          expect(current_path).to eq("/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit")
+          # save_and_open_page
+
+          within('#update_discount') do
+            expect(page).to have_content('Name:')
+            expect(page).to have_field(:bulk_discount_name, with: "Test1")
+            expect(page).to have_content('Discount percentage:')
+            expect(page).to have_field(:bulk_discount_percentage, with: 10)
+            expect(page).to have_content('Quantity required:')
+            expect(page).to have_field(:bulk_discount_quantity_threshold, with: 10)
+            expect(page).to have_button('Update Discount')
+          end
+        end
+
+        describe "When I correctly change any/all of the information and click submit" do
+          it "Then I am redirected to the bulk discount's show page. And I see that the discount's attributes have been updated" do
+            visit "/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit"
+
+            within('#update_discount') do
+              fill_in(:bulk_discount_name, with: "Test2")
+              fill_in(:bulk_discount_percentage, with: 10)
+              fill_in(:bulk_discount_quantity_threshold, with: 10)
+              click_button('Update Discount')
+            end
+
+            expect(current_path).to eq("/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}")
+            expect(page).to have_content('Information successfully updated')
+            expect(page).to have_content("Test2 Show Page")
+            expect(page).to_not have_content("Test1 Show Page")
+          end
+        end
+        describe "Sad path testing" do
+          describe "When I leave a form blank" do
+            it "I am redirected back to the edit page and an error message is displayed" do
+              visit "/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit"
+
+              within('#update_discount') do
+                fill_in(:bulk_discount_name, with: "")
+                fill_in(:bulk_discount_percentage, with: 20)
+                fill_in(:bulk_discount_quantity_threshold, with: 20)
+                click_button('Update Discount')
+              end
+
+              expect(current_path).to eq("/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit")
+              expect(page).to have_content('Required content missing or number input(s) are invalid')
+            end
+          end
+
+          describe "When I fill in percentage with a negative number" do
+            it "I am redirected back to the new page and an error message is displayed" do
+              visit "/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit"
+
+              within('#update_discount') do
+                fill_in(:bulk_discount_name, with: "Test1")
+                fill_in(:bulk_discount_percentage, with: -20)
+                fill_in(:bulk_discount_quantity_threshold, with: 20)
+                click_button('Update Discount')
+              end
+
+              expect(current_path).to eq("/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit")
+              expect(page).to have_content('Required content missing or number input(s) are invalid')
+            end
+          end
+
+          describe "When I fill in quantity_threshold with a negative number" do
+            it "I am redirected back to the new page and an error message is displayed" do
+              visit "/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit"
+
+              within('#update_discount') do
+                fill_in(:bulk_discount_name, with: "Test1")
+                fill_in(:bulk_discount_percentage, with: 20)
+                fill_in(:bulk_discount_quantity_threshold, with: -20)
+                click_button('Update Discount')
+              end
+
+              expect(current_path).to eq("/merchants/#{@merchant.id}/bulk_discounts/#{@discount1.id}/edit")
+              expect(page).to have_content('Required content missing or number input(s) are invalid')
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated