### PR TITLE
Feat aisp tot and disc rev/eli

### DIFF
--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -20,10 +20,13 @@
 <% @invoice.invoice_items.each do |invoice_item|%>
     <div id="item-<%= invoice_item.id %>">
     <h2>Item Name: <%= invoice_item.item.name %></h2>
-    <h3>Unit Price: <%= invoice_item.unit_price %></h3>
+    <h3>Unit Price: $<%= invoice_item.unit_price_to_dollars %></h3>
     <h4>Quantity: <%= invoice_item.quantity %></h4>
     <h5>Status: <%= invoice_item.status %></h5>
     </div>
 <% end %>
 <br>
-<h2>Total Revenue of All Items: <%= @invoice.total_revenue %></h2>
+<h2>Total Revenue of All Items: $<%= @invoice.total_revenue_to_dollars %></h2>
+<div id= "discounted_invoice_revenue">
+  <p><b>Discounted Invoice Revenue: </b><%= "$#{@invoice.discounted_invoice_revenue}" %></p>
+</div>

--- a/spec/features/admin/invoice/show_spec.rb
+++ b/spec/features/admin/invoice/show_spec.rb
@@ -1,59 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/invoices/invoice.id' do
-  before :each do
-    @customer_1 = Customer.create!(first_name: 'Eli', last_name: 'Fuchsman')
+  describe "As an admin" do
+    before :each do
+      @customer_1 = Customer.create!(first_name: 'Eli', last_name: 'Fuchsman')
 
-    @merchant = Merchant.create!(name: 'Test')
+      @merchant = Merchant.create!(name: 'Test')
 
-    @item_1 = Item.create!(name: 'item1', description: 'desc1', unit_price: 10, merchant_id: @merchant.id)
-    @item_2 = Item.create!(name: 'item2', description: 'desc2', unit_price: 12, merchant_id: @merchant.id)
+      @discount1 = BulkDiscount.create!(name: "Test1", percentage: 10, quantity_threshold: 10, merchant: @merchant)
 
-    @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 1, created_at: Time.parse('22.10.12'))
+      @item_1 = Item.create!(name: 'item1', description: 'desc1', unit_price: 10, merchant_id: @merchant.id)
+      @item_2 = Item.create!(name: 'item2', description: 'desc2', unit_price: 12, merchant_id: @merchant.id)
 
-    @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 1)
-    @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 11, unit_price: 12, status: 1)
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 1, created_at: Time.parse('22.10.12'))
 
-    @transaction_1 = Transaction.create!(credit_card_number: '1', result: 0, invoice_id: @invoice_1.id)
-    @transaction_2 = Transaction.create!(credit_card_number: '1', result: 0, invoice_id: @invoice_1.id)
-  end
-  describe 'invoice show, has invoice info, invoice items info, and total revenue' do
-    it 'shows related information to a specific invoice' do
-      visit "/admin/invoices/#{@invoice_1.id}"
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 1)
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 11, unit_price: 12, status: 1)
 
-      expect(page).to have_content("Id: #{@invoice_1.id}")
-      expect(page).to have_content('Status: completed')
-      expect(page).to have_content('Created at: Wednesday, October 12, 2022')
-      expect(page).to have_content('Customer Name: Eli Fuchsman')
+      @transaction_1 = Transaction.create!(credit_card_number: '1', result: 0, invoice_id: @invoice_1.id)
+      @transaction_2 = Transaction.create!(credit_card_number: '1', result: 0, invoice_id: @invoice_1.id)
     end
 
-    it 'shows all items on the invoice including item name, quantity, price, status' do
-      visit "/admin/invoices/#{@invoice_1.id}"
-      # within("#invoice_item-#{invoice}")
-      expect(page).to have_content('Invoice Items:')
-      expect(page).to have_content('Item Name: item1')
-      expect(page).to have_content('Unit Price: 10')
-      expect(page).to have_content('Quantity: 9')
-      expect(page).to have_content('Status: packaged')
+    describe "When I visit my invoice show page" do
+      describe 'invoice show, has invoice info, invoice items info, and total revenue' do
+        it 'shows related information to a specific invoice' do
+          visit "/admin/invoices/#{@invoice_1.id}"
 
-      expect(page).to have_content('Item Name: item2')
-      expect(page).to have_content('Unit Price: 12')
-      expect(page).to have_content('Quantity: 11')
-      expect(page).to have_content('Status: packaged')
-    end
-    #   When I visit an admin invoice show page
-    # Then I see the total revenue that will be generated from this invoice
-    it 'i see the total revenue that will be generated from this invoice' do
-      visit "/admin/invoices/#{@invoice_1.id}"
+          expect(page).to have_content("Id: #{@invoice_1.id}")
+          expect(page).to have_content('Status: completed')
+          expect(page).to have_content('Created at: Wednesday, October 12, 2022')
+          expect(page).to have_content('Customer Name: Eli Fuchsman')
+        end
 
-      expect(page).to have_content('Total Revenue of All Items: 222')
-    end
+        it 'shows all items on the invoice including item name, quantity, price, status' do
+          visit "/admin/invoices/#{@invoice_1.id}"
 
-    it 'can update invoice status from a select field' do
-      visit "/admin/invoices/#{@invoice_1.id}"
-      choose(:status, option: 'in progress')
-      click_on 'Update Invoice Status'
-      expect(page).to have_content('Status: in progress')
+          expect(page).to have_content('Invoice Items:')
+          expect(page).to have_content('Item Name: item1')
+          expect(page).to have_content('Unit Price: 10')
+          expect(page).to have_content('Quantity: 9')
+          expect(page).to have_content('Status: packaged')
+
+          expect(page).to have_content('Item Name: item2')
+          expect(page).to have_content('Unit Price: 12')
+          expect(page).to have_content('Quantity: 11')
+          expect(page).to have_content('Status: packaged')
+        end
+
+        it 'i see the total revenue that will be generated from this invoice' do
+          visit "/admin/invoices/#{@invoice_1.id}"
+
+          expect(page).to have_content('Total Revenue of All Items: 222')
+        end
+
+        it 'can update invoice status from a select field' do
+          visit "/admin/invoices/#{@invoice_1.id}"
+          choose(:status, option: 'in progress')
+          click_on 'Update Invoice Status'
+          expect(page).to have_content('Status: in progress')
+        end
+      end
     end
   end
 end

--- a/spec/features/admin/invoice/show_spec.rb
+++ b/spec/features/admin/invoice/show_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe 'admin/invoices/invoice.id' do
 
         it 'shows all items on the invoice including item name, quantity, price, status' do
           visit "/admin/invoices/#{@invoice_1.id}"
-
+          # save_and_open_page
           expect(page).to have_content('Invoice Items:')
           expect(page).to have_content('Item Name: item1')
-          expect(page).to have_content('Unit Price: 10')
+          expect(page).to have_content('Unit Price: $0.1')
           expect(page).to have_content('Quantity: 9')
           expect(page).to have_content('Status: packaged')
 
           expect(page).to have_content('Item Name: item2')
-          expect(page).to have_content('Unit Price: 12')
+          expect(page).to have_content('Unit Price: $0.12')
           expect(page).to have_content('Quantity: 11')
           expect(page).to have_content('Status: packaged')
         end
@@ -50,7 +50,7 @@ RSpec.describe 'admin/invoices/invoice.id' do
         it 'i see the total revenue that will be generated from this invoice' do
           visit "/admin/invoices/#{@invoice_1.id}"
 
-          expect(page).to have_content('Total Revenue of All Items: 222')
+          expect(page).to have_content('Total Revenue of All Items: $2.22')
         end
 
         it 'can update invoice status from a select field' do
@@ -58,6 +58,14 @@ RSpec.describe 'admin/invoices/invoice.id' do
           choose(:status, option: 'in progress')
           click_on 'Update Invoice Status'
           expect(page).to have_content('Status: in progress')
+        end
+
+        it "Then I see the total discounted revenue from this invoice as well" do
+          visit "/admin/invoices/#{@invoice_1.id}"
+
+          within("#discounted_invoice_revenue") do
+            expect(page).to have_content("Discounted Invoice Revenue: $2.09")
+          end
         end
       end
     end


### PR DESCRIPTION
8: Admin Invoice Show Page: Total Revenue and Discounted Revenue

As an admin
When I visit an admin invoice show page
Then I see the total revenue from this invoice (not including discounts)
And I see the total discounted revenue from this invoice which includes bulk discounts in the calculation