### PR TITLE
Feat holidays api/eli

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -4,6 +4,7 @@ class BulkDiscountsController < ApplicationController
 
   def index
     @bulk_discounts = @merchant.bulk_discounts
+    @holidays = HolidaySearch.new.upcoming_holidays
   end
 
   def show

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,8 @@
+class Holiday
+  attr_reader :local_name, :date
+
+  def initialize(data)
+    @local_name = data[:localName]
+    @date = data[:date]
+  end
+end

--- a/app/poros/holiday_search.rb
+++ b/app/poros/holiday_search.rb
@@ -1,0 +1,15 @@
+require './app/poros/holiday'
+require './app/services/nager_service'
+
+class HolidaySearch
+
+  def upcoming_holidays
+   service.holidays[0..2].map do |data|
+      Holiday.new(data)
+    end
+  end
+
+  def service
+    NagerService.new
+  end
+end

--- a/app/services/nager_service.rb
+++ b/app/services/nager_service.rb
@@ -1,0 +1,13 @@
+require 'httparty'
+
+class NagerService
+
+  def holidays
+    get_url("https://date.nager.at/Api/v2/NextPublicHolidays/US")
+  end
+
+  def get_url(url)
+    response = HTTParty.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -11,3 +11,11 @@
       ______________________________
   </div>
 <% end %>
+
+<section id= "upcoming_holidays">
+  <h4>Upcoming Holidays:<h4>
+  <% @holidays.each do |holiday| %>
+    <p><b>Holiday: </b><%= holiday.local_name %></p>
+    <p><b>Date: </b><%= holiday.date %></p>
+  <% end %>
+</section>

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -90,13 +90,19 @@ RSpec.describe "Merchant Bulk Discount Index Page" do
 
       describe "Holiday API call" do
         it "Shows the name and date of the next 3 upcoming US holidays" do
+          holidays = HolidaySearch.new.upcoming_holidays
           visit "/merchants/#{@merchant.id}/bulk_discounts"
-          save_and_open_page
+          # save_and_open_page
 
           within("#upcoming_holidays") do
             expect(page).to have_content("Upcoming Holidays:")
+            expect(page).to have_content("Holiday: #{holidays[0].local_name}")
+            expect(page).to have_content("Date: #{holidays[0].date}")
+            expect(page).to have_content("Holiday: #{holidays[1].local_name}")
+            expect(page).to have_content("Date: #{holidays[1].date}")
+            expect(page).to have_content("Holiday: #{holidays[2].local_name}")
+            expect(page).to have_content("Date: #{holidays[2].date}")
           end
-
         end
       end
     end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -87,6 +87,18 @@ RSpec.describe "Merchant Bulk Discount Index Page" do
           expect(page).to_not have_content("Quantity Required: 15")
         end
       end
+
+      describe "Holiday API call" do
+        it "Shows the name and date of the next 3 upcoming US holidays" do
+          visit "/merchants/#{@merchant.id}/bulk_discounts"
+          save_and_open_page
+
+          within("#upcoming_holidays") do
+            expect(page).to have_content("Upcoming Holidays:")
+          end
+
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
9: Holidays API

As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)